### PR TITLE
docs: update repository clone URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Convert YANG models to RDF.
 Clone the repository with submodules recursively
 
 ```bash
-git clone ssh://git@rnd-gitlab-eu.huawei.com:2222/irc-sdn/yang2rdf.git -b develop --recursive
+git clone https://github.com/Huawei-IOAM/yang2rdf.git --recursive
 ```
 
 Or, clone the repository and update the submodules
 
 ```bash
-git clone ssh://git@rnd-gitlab-eu.huawei.com:2222/irc-sdn/yang2rdf.git -b develop
+git clone https://github.com/Huawei-IOAM/yang2rdf.git
 git submodule update --init --recursive
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the repository URL to use the public GitHub repository instead of the internal Huawei GitLab repository.